### PR TITLE
fix(gcpkms): verify ciphertext_crc32c and AAD_crc32c on Decrypt response

### DIFF
--- a/tink/integration/gcpkms/BUILD.bazel
+++ b/tink/integration/gcpkms/BUILD.bazel
@@ -10,7 +10,10 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/crc:crc32c",
+        "@com_google_absl//absl/memory",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
         "@com_google_googleapis//google/cloud/kms/v1:kms_cc_grpc",
         "@com_googlesource_code_re2//:re2",
         "@google_cloud_cpp//:kms",

--- a/tink/integration/gcpkms/gcp_kms_aead.cc
+++ b/tink/integration/gcpkms/gcp_kms_aead.cc
@@ -16,12 +16,14 @@
 
 #include "tink/integration/gcpkms/gcp_kms_aead.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
 #include "google/cloud/kms/v1/service.grpc.pb.h"
 #include "grpcpp/client_context.h"
 #include "grpcpp/support/status.h"
+#include "absl/crc/crc32c.h"
 #include "absl/memory/memory.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
@@ -117,12 +119,48 @@ absl::StatusOr<std::string> GcpKmsAead::Decrypt(
   req.set_name(key_name_);
   req.set_ciphertext(ciphertext);
   req.set_additional_authenticated_data(associated_data);
+  // Set request-side CRC32C so the KMS server can verify request integrity
+  // and confirm receipt via the verified_*_crc32c response fields. See
+  // https://cloud.google.com/kms/docs/data-integrity-guidelines.
+  req.mutable_ciphertext_crc32c()->set_value(
+      static_cast<int64_t>(absl::ComputeCrc32c(ciphertext)));
+  req.mutable_additional_authenticated_data_crc32c()->set_value(
+      static_cast<int64_t>(absl::ComputeCrc32c(associated_data)));
   if (kms_client_) {
     auto response = kms_client_->Decrypt(req);
     if (!response.ok()) {
       return absl::Status(absl::StatusCode::kInvalidArgument,
                           absl::StrCat("GCP KMS decryption failed: ",
                                        response.status().message()));
+    }
+    if (!response->verified_ciphertext_crc32c()) {
+      return absl::Status(
+          absl::StatusCode::kInternal,
+          absl::StrCat(
+              "KMS request for ", key_name_,
+              " is missing the checksum field ciphertext_crc32c, and other "
+              "information may be missing from the response. Please retry a "
+              "limited number of times in case the error is transient."));
+    }
+    if (!response->verified_additional_authenticated_data_crc32c()) {
+      return absl::Status(
+          absl::StatusCode::kInternal,
+          absl::StrCat(
+              "KMS request for ", key_name_,
+              " is missing the checksum field "
+              "additional_authenticated_data_crc32c, and other information "
+              "may be missing from the response. Please retry a limited "
+              "number of times in case the error is transient."));
+    }
+    if (response->plaintext_crc32c().value() !=
+        static_cast<int64_t>(absl::ComputeCrc32c(response->plaintext()))) {
+      return absl::Status(
+          absl::StatusCode::kInternal,
+          absl::StrCat(
+              "KMS response corrupted in transit for ", key_name_,
+              ": the checksum in field plaintext_crc32c did not match the "
+              "data in field plaintext. Please retry in case this is a "
+              "transient error."));
     }
     return response->plaintext();
   }
@@ -138,6 +176,35 @@ absl::StatusOr<std::string> GcpKmsAead::Decrypt(
     return absl::Status(
         static_cast<absl::StatusCode>(status.error_code()),
         absl::StrCat("GCP KMS decryption failed: ", status.error_message()));
+  }
+  if (!resp.verified_ciphertext_crc32c()) {
+    return absl::Status(
+        absl::StatusCode::kInternal,
+        absl::StrCat(
+            "KMS request for ", key_name_,
+            " is missing the checksum field ciphertext_crc32c, and other "
+            "information may be missing from the response. Please retry a "
+            "limited number of times in case the error is transient."));
+  }
+  if (!resp.verified_additional_authenticated_data_crc32c()) {
+    return absl::Status(
+        absl::StatusCode::kInternal,
+        absl::StrCat(
+            "KMS request for ", key_name_,
+            " is missing the checksum field "
+            "additional_authenticated_data_crc32c, and other information may "
+            "be missing from the response. Please retry a limited number of "
+            "times in case the error is transient."));
+  }
+  if (resp.plaintext_crc32c().value() !=
+      static_cast<int64_t>(absl::ComputeCrc32c(resp.plaintext()))) {
+    return absl::Status(
+        absl::StatusCode::kInternal,
+        absl::StrCat(
+            "KMS response corrupted in transit for ", key_name_,
+            ": the checksum in field plaintext_crc32c did not match the data "
+            "in field plaintext. Please retry in case this is a transient "
+            "error."));
   }
   return resp.plaintext();
 }


### PR DESCRIPTION
Mirror of tink-go-gcpkms#21 for the C++ port.

## Background

[Cloud KMS Data Integrity Guidelines](https://cloud.google.com/kms/docs/data-integrity-guidelines) require AEAD requests carry CRC32C checksums on attacker-controlled fields and that the response carries `verified_*_crc32c` flags confirming the server received the request intact, plus `plaintext_crc32c` the client must verify against the recomputed checksum of returned plaintext.

The Go port (`tink-go-gcpkms`) was already setting request CRCs and [PR #21](https://github.com/tink-crypto/tink-go-gcpkms/pull/21) added the response-side verification. The C++ port was **missing both halves** on Decrypt:

- No request CRC was set (server cannot detect tampering on the wire)
- The `verified_*_crc32c` / `plaintext_crc32c` response fields were ignored (client cannot detect tampered KMS response)

## Change

The Decrypt path is now symmetric with the canonical Go pattern:

1. Set `req.ciphertext_crc32c` and `req.additional_authenticated_data_crc32c`
2. After the RPC, fail-closed on any of:
   - `!resp.verified_ciphertext_crc32c()`
   - `!resp.verified_additional_authenticated_data_crc32c()`
   - `resp.plaintext_crc32c() != ComputeCrc32c(resp.plaintext())`

Both the `kms_client_` (high-level Google Cloud C++ client) and `kms_stub_` (raw gRPC) code paths are updated.

## Scope

- This PR only touches `Decrypt` — exactly mirroring tink-go-gcpkms#21 scope
- The `Encrypt` path has the same gap and will get the symmetric fix in a follow-up PR
- Existing `gcp_kms_aead_test.cc` continues to use the mock connection (no behavioral break)

## Why mirror Go #21

Users running tink AEAD code today on the C++ port get strictly weaker integrity guarantees than the same code on the Go port. This brings parity for the Decrypt direction; symmetric fix for Encrypt to follow.

## References

- Cloud KMS Data Integrity Guidelines: https://cloud.google.com/kms/docs/data-integrity-guidelines
- Sibling Go PR: https://github.com/tink-crypto/tink-go-gcpkms/pull/21